### PR TITLE
GeoAsk Phases 2–3: AI orchestration layer + map/chat frontend

### DIFF
--- a/GeoAsk/README.md
+++ b/GeoAsk/README.md
@@ -5,9 +5,10 @@ map back — no GIS knowledge required. Built open-first (PostGIS + open data),
 with a clean path to ArcGIS deployment for clients who need the authoritative
 version.
 
-This repository currently contains the **foundation**: the deterministic spatial
-primitives engine (plan Phase 1) and the dev-environment scaffolding (Phase 0).
-The AI orchestration layer (Phase 2) and frontend (Phase 3) build on top of this
+This repository contains the **engine**: the deterministic spatial primitives
+(plan Phase 1), the dev-environment + PostGIS data layer (Phase 0), and the
+**AI orchestration layer** (Phase 2) that turns a plain-English question into a
+validated chain of primitive calls. The frontend (Phase 3) builds on top of this
 without changing it.
 
 ## Why this shape
@@ -79,6 +80,37 @@ schemas will mirror these request models. Malformed calls are rejected with a
 422 before any geometry runs, which is the first of the plan's validation
 guardrails.
 
+## AI orchestration (`app/orchestration/`)
+
+Phase 2 translates a plain-English question into a chain of primitive calls via
+LLM function calling (Claude, `claude-opus-4-8`, adaptive thinking). The pipeline
+is **parse → plan → execute → assemble**, and it holds the plan's load-bearing
+rule: *the LLM never touches raw data.*
+
+That rule is enforced structurally by a **layer store**. Every tool takes and
+returns opaque layer handles (`layer_1`, `layer_2`, …) plus a geometry-free
+summary (feature count, property names); the model chains steps by passing
+handles. It never sees a coordinate, which keeps its context small and means a
+malformed tool call can at worst name a handle that doesn't exist — which the
+executor rejects and hands back for repair.
+
+- **Tool schemas** (`tools.py`) mirror the primitives + two data-loading entry
+  points, so the model can only ever request validated operations.
+- **Guardrails**: the executor turns any primitive `ValueError` (bad distance,
+  unknown operator, empty layer) into an `is_error` tool result the model
+  corrects on its next turn — the request doesn't fail.
+- **Transparency trace**: every tool call and its geometry-free result is
+  recorded in order — the "what the AI did" panel, straight from the engine.
+- **Injectable boundaries**: both the LLM (`LLMClient`) and the data source
+  (`DataSource`) are protocols, so the whole loop is tested with a scripted fake
+  model and an in-memory source — a full multi-step access-gap chain, error
+  repair, bad-handle rejection, and the no-raw-geometry invariant, all with no
+  API key or database (`tests/test_orchestration.py`).
+
+Exposed as `POST /ask` (`{"question": "..."}` → `{geojson, explanation, trace}`);
+it returns 503 rather than pretending if `ANTHROPIC_API_KEY` or `DATABASE_URL`
+is unset.
+
 ## Data (`app/db.py`, `app/data_access.py`, `data/`, `sql/`)
 
 The PostGIS data layer is built: `sql/schema.sql` defines the indexed `pois` and
@@ -104,9 +136,9 @@ fetch of Overture/OSM POIs and Census/ACS tracts for a pilot bbox.
 ## Where this sits in the plan
 
 - **Phase 0 — Foundation:** ✅ PostGIS schema + data-access layer + loader, Docker compose, verified acceptance query
-- **Phase 1 — Spatial primitives:** ✅ implemented, tested (35 tests incl. live-PostGIS integration), exposed via API; isochrone backed by a routing engine
-- **Phase 2 — AI orchestration:** next — tool schemas over these endpoints, parse → plan → execute → assemble
-- **Phase 3 — Map & chat frontend:** MapLibre + chat + the transparency panel
+- **Phase 1 — Spatial primitives:** ✅ implemented, tested, exposed via API; isochrone backed by a routing engine
+- **Phase 2 — AI orchestration:** ✅ parse → plan → execute → assemble over the primitives, layer-handle isolation, guardrails, transparency trace, `POST /ask` (40 tests total, incl. a full scripted access-gap chain and live-PostGIS integration)
+- **Phase 3 — Map & chat frontend:** next — MapLibre + chat + the transparency panel (render `geojson` + `trace` from `/ask`)
 - **Phases 4–5 — MVP & pilot:** the access-gap finder, then real-user validation
 
 The `demo_access_gap.py` trace is a preview of the transparency panel: it prints

--- a/GeoAsk/README.md
+++ b/GeoAsk/README.md
@@ -111,6 +111,27 @@ Exposed as `POST /ask` (`{"question": "..."}` → `{geojson, explanation, trace}
 it returns 503 rather than pretending if `ANTHROPIC_API_KEY` or `DATABASE_URL`
 is unset.
 
+## Map & chat frontend (`app/web/`)
+
+Phase 3 is the usable surface: a map + chat page served by the app itself (open
+`/`). You type a question, the answer renders as a **toggleable map layer**, the
+model's plain-English explanation appears in the chat, and a **transparency
+panel** lists what the engine did, step by step — the plan's non-negotiable
+trust feature, rendered straight from the `/ask` trace. Session state keeps each
+result as its own layer so you can ask, refine, and compare.
+
+It's a self-contained page (MapLibre GL for the map) rather than a React build —
+no toolchain, served directly by FastAPI. If the map library can't load (offline
+or restricted network) the page **degrades gracefully**: answers and the
+transparency trace still work, layers are still listed; only the map canvas is
+omitted.
+
+Because a live map needs an API key and database, there's a **no-config demo**:
+click *Try a sample question* (or `POST /ask/demo`) to run the real orchestrator
+over in-memory sample data via a scripted planner — a genuine access-gap result
+and trace with nothing to set up. It's how the frontend is tested in CI
+(`tests/test_frontend.py`).
+
 ## Data (`app/db.py`, `app/data_access.py`, `data/`, `sql/`)
 
 The PostGIS data layer is built: `sql/schema.sql` defines the indexed `pois` and
@@ -137,8 +158,8 @@ fetch of Overture/OSM POIs and Census/ACS tracts for a pilot bbox.
 
 - **Phase 0 — Foundation:** ✅ PostGIS schema + data-access layer + loader, Docker compose, verified acceptance query
 - **Phase 1 — Spatial primitives:** ✅ implemented, tested, exposed via API; isochrone backed by a routing engine
-- **Phase 2 — AI orchestration:** ✅ parse → plan → execute → assemble over the primitives, layer-handle isolation, guardrails, transparency trace, `POST /ask` (40 tests total, incl. a full scripted access-gap chain and live-PostGIS integration)
-- **Phase 3 — Map & chat frontend:** next — MapLibre + chat + the transparency panel (render `geojson` + `trace` from `/ask`)
+- **Phase 2 — AI orchestration:** ✅ parse → plan → execute → assemble over the primitives, layer-handle isolation, guardrails, transparency trace, `POST /ask`
+- **Phase 3 — Map & chat frontend:** ✅ served at `/` — map + chat + toggleable layers + transparency panel, graceful offline degradation, and a no-config `/ask/demo` (44 tests total, incl. the served page, the demo pipeline, a scripted access-gap chain, and live-PostGIS integration)
 - **Phases 4–5 — MVP & pilot:** the access-gap finder, then real-user validation
 
 The `demo_access_gap.py` trace is a preview of the transparency panel: it prints

--- a/GeoAsk/app/main.py
+++ b/GeoAsk/app/main.py
@@ -1,27 +1,40 @@
-"""GeoAsk API entry point.
+"""GeoAsk API + frontend entry point.
 
-Right now this exposes the deterministic spatial-primitive layer (Phase 1). The
-AI orchestration layer (Phase 2) will mount here too, calling these same
-endpoints via their tool schemas — it will not gain any privileged path to the
-data. Run locally with:
+Exposes the deterministic spatial-primitive layer (Phase 1), the AI
+orchestration layer (Phase 2, ``/ask``), and serves the map + chat frontend
+(Phase 3) as static files. Run locally with:
 
-    uvicorn app.main:app --reload
+    uvicorn app.main:app --reload   # UI at http://localhost:8000/
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from .routers import ask, primitives
 
+_WEB_DIR = Path(__file__).resolve().parent / "web"
+
 app = FastAPI(
     title="GeoAsk",
-    version="0.2.0",
-    summary="Natural-language-to-map engine — primitives + AI orchestration",
+    version="0.3.0",
+    summary="Natural-language-to-map engine — primitives + AI orchestration + map/chat UI",
 )
 
 app.include_router(primitives.router)
 app.include_router(ask.router)
+
+# Static assets (JS/CSS) for the frontend.
+app.mount("/static", StaticFiles(directory=_WEB_DIR), name="static")
+
+
+@app.get("/", include_in_schema=False)
+def index():
+    return FileResponse(_WEB_DIR / "index.html")
 
 
 @app.get("/health", tags=["meta"])

--- a/GeoAsk/app/main.py
+++ b/GeoAsk/app/main.py
@@ -12,15 +12,16 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from .routers import primitives
+from .routers import ask, primitives
 
 app = FastAPI(
     title="GeoAsk",
-    version="0.1.0",
-    summary="Natural-language-to-map engine — spatial primitives layer",
+    version="0.2.0",
+    summary="Natural-language-to-map engine — primitives + AI orchestration",
 )
 
 app.include_router(primitives.router)
+app.include_router(ask.router)
 
 
 @app.get("/health", tags=["meta"])

--- a/GeoAsk/app/orchestration/__init__.py
+++ b/GeoAsk/app/orchestration/__init__.py
@@ -1,0 +1,18 @@
+"""Phase 2 — the AI orchestration layer.
+
+Translates a plain-English question into a chain of Phase 1 primitive calls via
+LLM function calling. The model only ever calls the validated tools and only
+ever sees layer handles + summaries, never raw geometry.
+"""
+
+from .orchestrator import AskResult, TraceStep, ask
+from .sources import DataSource, InMemoryDataSource, PostgisDataSource
+
+__all__ = [
+    "ask",
+    "AskResult",
+    "TraceStep",
+    "DataSource",
+    "InMemoryDataSource",
+    "PostgisDataSource",
+]

--- a/GeoAsk/app/orchestration/demo.py
+++ b/GeoAsk/app/orchestration/demo.py
@@ -1,0 +1,64 @@
+"""A no-config demo of the orchestration layer.
+
+Runs the real orchestrator — layer store, executor, guardrails, transparency
+trace — over small in-memory sample data (a Portland-area pharmacy and three
+tracts) using a scripted planner instead of a live LLM. It produces a genuine
+access-gap result and trace, so the frontend can be seen working without an API
+key or database. The planning is canned; everything downstream is real.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .llm import ScriptedClient
+from .orchestrator import AskResult, ask
+from .sources import InMemoryDataSource
+
+LON, LAT = -122.68, 45.52
+
+
+def _point(lon, lat, **props):
+    return {"type": "Feature", "geometry": {"type": "Point", "coordinates": [lon, lat]}, "properties": props}
+
+
+def _tract(name, x0, y0, size, **props):
+    ring = [[x0, y0], [x0 + size, y0], [x0 + size, y0 + size], [x0, y0 + size], [x0, y0]]
+    return {
+        "type": "Feature",
+        "geometry": {"type": "Polygon", "coordinates": [ring]},
+        "properties": {"tract": name, **props},
+    }
+
+
+def _sample_source() -> InMemoryDataSource:
+    pharmacies = {"type": "FeatureCollection", "features": [_point(LON, LAT, name="Central Pharmacy")]}
+    tracts = {
+        "type": "FeatureCollection",
+        "features": [
+            _tract("near-young", LON - 0.01, LAT - 0.01, 0.02, population=1500, pct_senior=8.0),
+            _tract("far-senior", LON + 0.20, LAT, 0.02, population=1200, pct_senior=27.0),
+            _tract("far-young", LON + 0.20, LAT + 0.03, 0.02, population=1800, pct_senior=9.0),
+        ],
+    }
+    return InMemoryDataSource({"pharmacy": pharmacies}, tracts)
+
+
+# The canned plan for: "neighbourhoods >10 min from a pharmacy with above-average
+# seniors" — the same chain a live model produces for this question type.
+_PLAN: list[list[tuple[str, dict[str, Any]]]] = [
+    [("load_pois", {"category": "pharmacy"})],
+    [("isochrone", {"layer_id": "layer_1", "minutes": 10, "mode": "drive"})],
+    [("load_tracts", {})],
+    [("spatial_join", {"target_layer_id": "layer_3", "join_layer_id": "layer_2",
+                       "predicate": "intersects", "keep": "non_matching"})],
+    [("filter_by_attribute", {"layer_id": "layer_4", "attribute": "pct_senior", "op": ">", "value": 15})],
+    [("finish", {"layer_id": "layer_5", "explanation":
+                 "I found pharmacies, built 10-minute drive-time areas around them, "
+                 "selected the neighbourhoods that fall outside every drive-time area, "
+                 "and kept the ones with an above-average senior population."})],
+]
+
+
+def run_demo() -> AskResult:
+    return ask("sample question", ScriptedClient(_PLAN), _sample_source())

--- a/GeoAsk/app/orchestration/layers.py
+++ b/GeoAsk/app/orchestration/layers.py
@@ -1,0 +1,53 @@
+"""The layer store — the enforcement point for "the LLM never touches raw data".
+
+Every spatial result lives here as a GeoJSON FeatureCollection keyed by an
+opaque handle (``layer_1``, ``layer_2``, …). The LLM only ever sees a *summary*
+of a layer (feature count, geometry type, property names, a couple of sample
+values) — never the coordinates. It chains operations by passing handles
+between tools. This keeps the model's context small and cheap, and means a
+malformed model output can never corrupt the underlying data: the worst it can
+do is name a handle that doesn't exist, which the executor rejects.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+from ..spatial.geo import features_of
+
+
+class LayerStore:
+    def __init__(self) -> None:
+        self._layers: dict[str, dict[str, Any]] = {}
+        self._counter = itertools.count(1)
+
+    def add(self, fc: dict[str, Any]) -> str:
+        """Store a FeatureCollection and return its new handle."""
+        layer_id = f"layer_{next(self._counter)}"
+        self._layers[layer_id] = fc
+        return layer_id
+
+    def get(self, layer_id: str) -> dict[str, Any]:
+        if layer_id not in self._layers:
+            raise KeyError(layer_id)
+        return self._layers[layer_id]
+
+    def summary(self, layer_id: str) -> dict[str, Any]:
+        """A compact, geometry-free description for the LLM."""
+        fc = self.get(layer_id)
+        feats = features_of(fc)
+        geom_type = None
+        props: dict[str, Any] = {}
+        if feats:
+            geom = feats[0].get("geometry") or {}
+            geom_type = geom.get("type")
+            props = feats[0].get("properties") or {}
+        return {
+            "layer_id": layer_id,
+            "feature_count": len(feats),
+            "geometry_type": geom_type,
+            # Property names plus one sample value each, so the model knows what
+            # it can filter or overlay on — without shipping every row.
+            "properties": {k: props[k] for k in list(props)[:12]},
+        }

--- a/GeoAsk/app/orchestration/llm.py
+++ b/GeoAsk/app/orchestration/llm.py
@@ -1,0 +1,55 @@
+"""The LLM boundary.
+
+The orchestrator depends on a small ``LLMClient`` protocol, not on the Anthropic
+SDK directly, so the parse→plan→execute→assemble loop can be driven by a scripted
+fake in tests (no API key, deterministic) and by real Claude in production. This
+mirrors how the isochrone router and the PostGIS source are injected.
+
+``AnthropicClient`` uses Claude with adaptive thinking. Tool schemas come from
+``tools.TOOL_SCHEMAS``; the model plans in terms of those validated operations.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Protocol
+
+MODEL = "claude-opus-4-8"
+
+
+class LLMClient(Protocol):
+    def respond(
+        self, system: str, tools: list[dict[str, Any]], messages: list[dict[str, Any]]
+    ) -> Any:
+        """Return an object exposing ``.content`` (a list of blocks, each with a
+        ``.type``; tool_use blocks also carry ``.id``/``.name``/``.input``) and
+        ``.stop_reason``. The returned ``.content`` is appended verbatim to the
+        message history, so it must round-trip back to the same client."""
+        ...
+
+
+class AnthropicClient:
+    def __init__(self, model: str = MODEL, max_tokens: int = 8000):
+        import anthropic
+
+        self._client = anthropic.Anthropic()  # resolves ANTHROPIC_API_KEY / profile
+        self._model = model
+        self._max_tokens = max_tokens
+
+    def respond(self, system, tools, messages):
+        return self._client.messages.create(
+            model=self._model,
+            max_tokens=self._max_tokens,
+            thinking={"type": "adaptive"},
+            system=system,
+            tools=tools,
+            messages=messages,
+        )
+
+
+def default_client() -> LLMClient | None:
+    """A real client if credentials are configured, else ``None`` so callers can
+    fall back (the orchestrator requires an explicit client in tests)."""
+    if os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_AUTH_TOKEN"):
+        return AnthropicClient()
+    return None

--- a/GeoAsk/app/orchestration/llm.py
+++ b/GeoAsk/app/orchestration/llm.py
@@ -47,6 +47,33 @@ class AnthropicClient:
         )
 
 
+class ScriptedClient:
+    """A deterministic ``LLMClient`` that replays a fixed plan of tool calls.
+
+    Not an LLM — it plays a pre-written list of turns (each a list of
+    ``(tool_name, args)``). Used to demo and test the orchestration loop with no
+    API key: the loop, guardrails, layer store, and trace are exercised for real;
+    only the *planning* is canned. Because layer handles are deterministic
+    (layer_1, layer_2, …), a plan can reference the handles earlier steps produce.
+    """
+
+    def __init__(self, turns: list[list[tuple[str, dict[str, Any]]]]):
+        from types import SimpleNamespace
+
+        self._turns = turns
+        self._i = 0
+        self._ns = SimpleNamespace
+
+    def respond(self, system, tools, messages):
+        turn = self._turns[self._i]
+        self._i += 1
+        content = [
+            self._ns(type="tool_use", id=f"t{self._i}_{j}", name=name, input=args)
+            for j, (name, args) in enumerate(turn)
+        ]
+        return self._ns(content=content, stop_reason="tool_use")
+
+
 def default_client() -> LLMClient | None:
     """A real client if credentials are configured, else ``None`` so callers can
     fall back (the orchestrator requires an explicit client in tests)."""

--- a/GeoAsk/app/orchestration/orchestrator.py
+++ b/GeoAsk/app/orchestration/orchestrator.py
@@ -1,0 +1,142 @@
+"""The orchestration loop: plain-English question -> chain of primitive calls.
+
+Runs a manual tool-use loop (chosen over the SDK tool runner so the whole thing
+stays driven by the injected ``LLMClient`` protocol and is testable with a
+scripted fake). On each turn the model either calls tools or finishes:
+
+    parse  -> the model reads the question + tool results so far
+    plan   -> it emits tool_use blocks (which tools, what order)
+    execute-> ToolExecutor runs them against the primitives; errors come back as
+              is_error results the model can repair
+    assemble-> when it calls ``finish``, we return that layer's GeoJSON, the
+              model's plain-English explanation, and the full step-by-step trace
+
+The trace is the transparency panel the plan calls non-negotiable: every tool
+call and its geometry-free result, in order.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .layers import LayerStore
+from .llm import LLMClient
+from .sources import DataSource
+from .tools import TOOL_SCHEMAS, ToolExecutor
+
+SYSTEM_PROMPT = """You are the planning engine of GeoAsk, a natural-language-to-map tool.
+
+You answer spatial questions by calling a fixed set of validated spatial tools.
+You never see or handle raw geometry — every tool takes and returns opaque layer
+handles (e.g. "layer_3") plus a summary (feature count, property names). Chain
+tools by passing handles between them.
+
+Typical access-gap pattern: load the facilities (load_pois), build reachable
+areas around them (isochrone), find the tracts outside every area
+(spatial_join with keep="non_matching"), attach or filter on demographics
+(demographic_overlay / filter_by_attribute), then call finish with the final
+layer and a clear step-by-step explanation for a non-technical user.
+
+Only use the property names a layer's summary actually reports. If a tool returns
+an error, read it and correct your next call. When the answer layer is ready,
+call finish — do not stop without calling it."""
+
+
+@dataclass
+class TraceStep:
+    tool: str
+    args: dict[str, Any]
+    result: dict[str, Any]
+    is_error: bool
+
+
+@dataclass
+class AskResult:
+    geojson: dict[str, Any] | None
+    explanation: str
+    trace: list[TraceStep] = field(default_factory=list)
+    finished: bool = False
+
+
+def ask(
+    question: str,
+    client: LLMClient,
+    source: DataSource,
+    *,
+    max_turns: int = 12,
+) -> AskResult:
+    store = LayerStore()
+    executor = ToolExecutor(store, source)
+    messages: list[dict[str, Any]] = [{"role": "user", "content": question}]
+    trace: list[TraceStep] = []
+
+    for _ in range(max_turns):
+        response = client.respond(SYSTEM_PROMPT, TOOL_SCHEMAS, messages)
+        messages.append({"role": "assistant", "content": response.content})
+
+        tool_uses = [b for b in response.content if getattr(b, "type", None) == "tool_use"]
+        if not tool_uses:
+            # Model answered in prose without producing a map.
+            return AskResult(
+                geojson=None,
+                explanation=_text_of(response.content),
+                trace=trace,
+                finished=False,
+            )
+
+        tool_results = []
+        for block in tool_uses:
+            if block.name == "finish":
+                layer_id = block.input.get("layer_id")
+                explanation = block.input.get("explanation", "")
+                try:
+                    geojson = store.get(layer_id)
+                except KeyError:
+                    # Guardrail: finish named a non-existent layer — tell the
+                    # model so it can pick a real one instead of failing.
+                    tool_results.append(_error_result(block.id, f"no such layer: {layer_id}"))
+                    continue
+                trace.append(TraceStep("finish", dict(block.input), {"layer_id": layer_id}, False))
+                return AskResult(geojson=geojson, explanation=explanation, trace=trace, finished=True)
+
+            result, is_error = executor.execute(block.name, block.input)
+            trace.append(TraceStep(block.name, dict(block.input), result, is_error))
+            tool_results.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": _to_text(result),
+                    "is_error": is_error,
+                }
+            )
+
+        if tool_results:
+            messages.append({"role": "user", "content": tool_results})
+
+    return AskResult(
+        geojson=None,
+        explanation="Stopped: the plan did not converge within the step budget.",
+        trace=trace,
+        finished=False,
+    )
+
+
+def _to_text(result: dict[str, Any]) -> str:
+    import json
+
+    return json.dumps(result)
+
+
+def _error_result(tool_use_id: str, message: str) -> dict[str, Any]:
+    return {
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "content": message,
+        "is_error": True,
+    }
+
+
+def _text_of(content: Any) -> str:
+    parts = [getattr(b, "text", "") for b in content if getattr(b, "type", None) == "text"]
+    return " ".join(p for p in parts if p).strip()

--- a/GeoAsk/app/orchestration/sources.py
+++ b/GeoAsk/app/orchestration/sources.py
@@ -1,0 +1,53 @@
+"""Data sources the orchestration layer can load base layers from.
+
+The tools that fetch data (``load_pois``, ``load_tracts``) go through a
+``DataSource`` protocol rather than talking to PostGIS directly. That keeps the
+orchestrator testable with an in-memory source (no database) and lets the same
+tool code run against real PostGIS in production — the primitives never change,
+only where the GeoJSON originates.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class DataSource(Protocol):
+    def load_pois(self, category: str) -> dict[str, Any]:
+        """POIs of a category as a GeoJSON FeatureCollection."""
+        ...
+
+    def load_tracts(self) -> dict[str, Any]:
+        """Census tracts as a GeoJSON FeatureCollection."""
+        ...
+
+
+class InMemoryDataSource:
+    """Fixed FeatureCollections keyed by POI category, for demos and tests."""
+
+    def __init__(self, pois_by_category: dict[str, dict[str, Any]], tracts: dict[str, Any]):
+        self._pois = pois_by_category
+        self._tracts = tracts
+
+    def load_pois(self, category: str) -> dict[str, Any]:
+        return self._pois.get(category, {"type": "FeatureCollection", "features": []})
+
+    def load_tracts(self) -> dict[str, Any]:
+        return self._tracts
+
+
+class PostgisDataSource:
+    """Loads base layers from PostGIS via the data-access module."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    def load_pois(self, category: str) -> dict[str, Any]:
+        from .. import data_access
+
+        return data_access.pois_by_category(self._conn, category)
+
+    def load_tracts(self) -> dict[str, Any]:
+        from .. import data_access
+
+        return data_access.all_tracts(self._conn)

--- a/GeoAsk/app/orchestration/tools.py
+++ b/GeoAsk/app/orchestration/tools.py
@@ -1,0 +1,234 @@
+"""Tool schemas for LLM function calling, and the executor that runs them.
+
+The schemas mirror the Phase 1 primitives (and the two data-loading entry
+points) so the model plans in terms of the exact validated operations the engine
+supports — it cannot invent an operation, and it cannot pass raw geometry. Every
+tool takes/returns layer handles (see ``layers.py``).
+
+The executor is the validation guardrail: it confirms referenced handles exist,
+dispatches to the pure primitive, and turns any ``ValueError`` (bad distance,
+unknown operator, empty layer) into an ``is_error`` tool result so the model can
+repair its own call instead of the whole request failing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .. import spatial
+from .layers import LayerStore
+from .sources import DataSource
+
+# --- schemas presented to the model ------------------------------------------
+
+TOOL_SCHEMAS: list[dict[str, Any]] = [
+    {
+        "name": "load_pois",
+        "description": (
+            "Load points of interest of a given category (e.g. 'pharmacy', "
+            "'school', 'grocery') as a new layer. Start here to get the "
+            "facilities a question is about."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {"category": {"type": "string"}},
+            "required": ["category"],
+        },
+    },
+    {
+        "name": "load_tracts",
+        "description": (
+            "Load census tracts (with population, pct_senior, median_income) as "
+            "a new layer. Use for the neighbourhoods/areas a question asks about."
+        ),
+        "input_schema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "isochrone",
+        "description": (
+            "Build travel-time reachable areas around each feature of a layer. "
+            "Returns a new polygon layer."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "layer_id": {"type": "string"},
+                "minutes": {"type": "number"},
+                "mode": {"type": "string", "enum": ["walk", "bike", "drive"]},
+            },
+            "required": ["layer_id", "minutes"],
+        },
+    },
+    {
+        "name": "buffer",
+        "description": "Grow each feature of a layer by a distance in metres. Returns a new polygon layer.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "layer_id": {"type": "string"},
+                "distance_m": {"type": "number"},
+            },
+            "required": ["layer_id", "distance_m"],
+        },
+    },
+    {
+        "name": "spatial_join",
+        "description": (
+            "Relate a target layer to a join layer by a topological predicate. "
+            "keep='non_matching' returns the target features NOT related to any "
+            "join feature — that is the access gap (e.g. tracts outside every "
+            "drive-time area)."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "target_layer_id": {"type": "string"},
+                "join_layer_id": {"type": "string"},
+                "predicate": {"type": "string", "enum": ["intersects", "within", "contains"]},
+                "keep": {"type": "string", "enum": ["matching", "non_matching"]},
+            },
+            "required": ["target_layer_id", "join_layer_id"],
+        },
+    },
+    {
+        "name": "filter_by_attribute",
+        "description": "Keep only features whose property passes a comparison. Returns a new layer.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "layer_id": {"type": "string"},
+                "attribute": {"type": "string"},
+                "op": {"type": "string", "enum": ["==", "!=", ">", ">=", "<", "<="]},
+                "value": {"description": "Number, string, or boolean to compare against"},
+            },
+            "required": ["layer_id", "attribute", "op", "value"],
+        },
+    },
+    {
+        "name": "demographic_overlay",
+        "description": (
+            "Area-weighted aggregation of a tract value onto areas. kind='extensive' "
+            "for counts (population), 'intensive' for rates (pct_senior). Returns "
+            "the areas layer with the value attached."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "areas_layer_id": {"type": "string"},
+                "tracts_layer_id": {"type": "string"},
+                "value_field": {"type": "string"},
+                "kind": {"type": "string", "enum": ["extensive", "intensive"]},
+                "out_field": {"type": "string"},
+            },
+            "required": ["areas_layer_id", "tracts_layer_id", "value_field"],
+        },
+    },
+    {
+        "name": "nearest",
+        "description": (
+            "For each feature of a source layer, attach the distance in metres to "
+            "the nearest destination-layer feature. Returns the source layer "
+            "annotated with _nearest_distance_m."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "source_layer_id": {"type": "string"},
+                "destinations_layer_id": {"type": "string"},
+            },
+            "required": ["source_layer_id", "destinations_layer_id"],
+        },
+    },
+    {
+        "name": "finish",
+        "description": (
+            "Call when the answer layer is ready. Provide the final layer_id and a "
+            "one-paragraph plain-English explanation of what the engine did, step "
+            "by step, for the transparency panel."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "layer_id": {"type": "string"},
+                "explanation": {"type": "string"},
+            },
+            "required": ["layer_id", "explanation"],
+        },
+    },
+]
+
+
+class ToolExecutor:
+    """Runs a single tool call against the primitives and the layer store."""
+
+    def __init__(self, store: LayerStore, source: DataSource):
+        self.store = store
+        self.source = source
+
+    def execute(self, name: str, args: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+        """Return (result, is_error). ``result`` is JSON-safe and geometry-free."""
+        try:
+            handler = getattr(self, f"_{name}", None)
+            if handler is None:
+                return {"error": f"unknown tool {name!r}"}, True
+            return handler(args), False
+        except KeyError as exc:
+            return {"error": f"no such layer: {exc}"}, True
+        except ValueError as exc:
+            return {"error": str(exc)}, True
+
+    # data loading -----------------------------------------------------------
+
+    def _load_pois(self, a):
+        fc = self.source.load_pois(a["category"])
+        return self._store_summary(fc)
+
+    def _load_tracts(self, a):
+        return self._store_summary(self.source.load_tracts())
+
+    # primitives -------------------------------------------------------------
+
+    def _isochrone(self, a):
+        fc = self.store.get(a["layer_id"])
+        out = spatial.isochrone(fc, a["minutes"], a.get("mode", "drive"))
+        return self._store_summary(out)
+
+    def _buffer(self, a):
+        out = spatial.buffer(self.store.get(a["layer_id"]), a["distance_m"])
+        return self._store_summary(out)
+
+    def _spatial_join(self, a):
+        out = spatial.spatial_join(
+            self.store.get(a["target_layer_id"]),
+            self.store.get(a["join_layer_id"]),
+            a.get("predicate", "intersects"),
+            a.get("keep", "matching"),
+        )
+        return self._store_summary(out)
+
+    def _filter_by_attribute(self, a):
+        out = spatial.filter_by_attribute(
+            self.store.get(a["layer_id"]), a["attribute"], a["op"], a["value"]
+        )
+        return self._store_summary(out)
+
+    def _demographic_overlay(self, a):
+        out = spatial.demographic_overlay(
+            self.store.get(a["areas_layer_id"]),
+            self.store.get(a["tracts_layer_id"]),
+            a["value_field"],
+            a.get("kind", "extensive"),
+            a.get("out_field"),
+        )
+        return self._store_summary(out)
+
+    def _nearest(self, a):
+        out = spatial.nearest(
+            self.store.get(a["source_layer_id"]), self.store.get(a["destinations_layer_id"])
+        )
+        return self._store_summary(out)
+
+    # helper -----------------------------------------------------------------
+
+    def _store_summary(self, fc: dict[str, Any]) -> dict[str, Any]:
+        return self.store.summary(self.store.add(fc))

--- a/GeoAsk/app/routers/ask.py
+++ b/GeoAsk/app/routers/ask.py
@@ -41,6 +41,25 @@ class AskResponse(BaseModel):
     trace: list[TraceStepModel]
 
 
+def _to_response(result) -> "AskResponse":
+    return AskResponse(
+        finished=result.finished,
+        explanation=result.explanation,
+        geojson=result.geojson,
+        trace=[TraceStepModel(tool=s.tool, args=s.args, result=s.result, is_error=s.is_error)
+               for s in result.trace],
+    )
+
+
+@router.post("/demo", response_model=AskResponse)
+def ask_demo():
+    """Run the orchestrator over in-memory sample data with a scripted planner —
+    no API key or database needed. Lets the frontend be demoed end-to-end."""
+    from ..orchestration.demo import run_demo
+
+    return _to_response(run_demo())
+
+
 @router.post("", response_model=AskResponse)
 def ask_question(req: AskRequest):
     client = default_client()
@@ -54,10 +73,4 @@ def ask_question(req: AskRequest):
     with db.connect(url) as conn:
         result = ask(req.question, client, PostgisDataSource(conn))
 
-    return AskResponse(
-        finished=result.finished,
-        explanation=result.explanation,
-        geojson=result.geojson,
-        trace=[TraceStepModel(tool=s.tool, args=s.args, result=s.result, is_error=s.is_error)
-               for s in result.trace],
-    )
+    return _to_response(result)

--- a/GeoAsk/app/routers/ask.py
+++ b/GeoAsk/app/routers/ask.py
@@ -1,0 +1,63 @@
+"""The /ask endpoint — plain-English question in, map + transparency out.
+
+This is the product surface: a non-technical user's question goes to the
+orchestration layer, which drives the primitives via LLM function calling and
+returns the answer layer as GeoJSON plus the step-by-step trace for the
+transparency panel.
+
+Requires a configured LLM (ANTHROPIC_API_KEY) and a PostGIS connection
+(DATABASE_URL); returns 503 if either is missing rather than pretending.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from .. import db
+from ..orchestration import PostgisDataSource, ask
+from ..orchestration.llm import default_client
+
+router = APIRouter(prefix="/ask", tags=["orchestration"])
+
+
+class AskRequest(BaseModel):
+    question: str
+
+
+class TraceStepModel(BaseModel):
+    tool: str
+    args: dict[str, Any]
+    result: dict[str, Any]
+    is_error: bool
+
+
+class AskResponse(BaseModel):
+    finished: bool
+    explanation: str
+    geojson: dict[str, Any] | None
+    trace: list[TraceStepModel]
+
+
+@router.post("", response_model=AskResponse)
+def ask_question(req: AskRequest):
+    client = default_client()
+    if client is None:
+        raise HTTPException(503, "LLM not configured (set ANTHROPIC_API_KEY)")
+    try:
+        url = db.database_url()
+    except RuntimeError as exc:
+        raise HTTPException(503, str(exc)) from exc
+
+    with db.connect(url) as conn:
+        result = ask(req.question, client, PostgisDataSource(conn))
+
+    return AskResponse(
+        finished=result.finished,
+        explanation=result.explanation,
+        geojson=result.geojson,
+        trace=[TraceStepModel(tool=s.tool, args=s.args, result=s.result, is_error=s.is_error)
+               for s in result.trace],
+    )

--- a/GeoAsk/app/web/app.js
+++ b/GeoAsk/app/web/app.js
@@ -1,0 +1,248 @@
+"use strict";
+
+// GeoAsk frontend: chat -> POST /ask -> render the answer layer + transparency
+// trace. State is a list of result layers the user can toggle; each /ask call is
+// independent (the backend is stateless per request), which is enough for the
+// MVP's "ask, refine, ask again" loop.
+
+const PORTLAND = [-122.68, 45.52];
+const PALETTE = ["#2f6fed", "#e8590c", "#2f9e44", "#9c36b5", "#e03131", "#0c8599"];
+
+// The map library loads from a CDN; if that's blocked (offline/restricted
+// network) the app still works — it shows each answer's explanation and
+// transparency trace, just without the map canvas.
+const MAP_OK = typeof maplibregl !== "undefined";
+
+let map = null;
+let mapReady = false;
+const pending = [];
+
+if (MAP_OK) {
+  map = new maplibregl.Map({
+    container: "map",
+    style: "https://demotiles.maplibre.org/style.json",
+    center: PORTLAND,
+    zoom: 8.5,
+  });
+  map.addControl(new maplibregl.NavigationControl(), "top-right");
+  map.on("load", () => {
+    mapReady = true;
+    pending.forEach((fn) => fn());
+    pending.length = 0;
+  });
+} else {
+  const el = document.getElementById("map");
+  el.innerHTML =
+    '<div style="display:flex;height:100%;align-items:center;justify-content:center;' +
+    'color:var(--muted);padding:24px;text-align:center">' +
+    "Map library unavailable on this network — answers and the transparency trace " +
+    "still work; layers are listed on the left.</div>";
+}
+
+function whenReady(fn) {
+  if (!MAP_OK) return;
+  if (mapReady) fn();
+  else pending.push(fn);
+}
+
+const state = { layers: [], seq: 0 };
+
+const els = {
+  messages: document.getElementById("messages"),
+  form: document.getElementById("ask-form"),
+  question: document.getElementById("question"),
+  askButton: document.getElementById("ask-button"),
+  demoButton: document.getElementById("demo-button"),
+  layersPanel: document.getElementById("layers-panel"),
+  layers: document.getElementById("layers"),
+};
+
+// --- messaging --------------------------------------------------------------
+
+function addMessage(text, kind, swatch) {
+  const div = document.createElement("div");
+  div.className = `msg ${kind}`;
+  if (swatch) {
+    const dot = document.createElement("span");
+    dot.className = "swatch";
+    dot.style.background = swatch;
+    div.appendChild(dot);
+  }
+  div.appendChild(document.createTextNode(text));
+  els.messages.appendChild(div);
+  els.messages.scrollTop = els.messages.scrollHeight;
+  return div;
+}
+
+function addThinking() {
+  const div = addMessage("Working", "assistant");
+  div.classList.add("thinking");
+  return div;
+}
+
+// --- transparency trace -----------------------------------------------------
+
+function describeStep(step) {
+  const a = step.args || {};
+  const n = step.result && step.result.feature_count;
+  if (step.is_error) return `${step.tool}: ${step.result.error}`;
+  switch (step.tool) {
+    case "load_pois": return `Loaded ${n} “${a.category}” location(s)`;
+    case "load_tracts": return `Loaded ${n} census tracts`;
+    case "isochrone": return `Built ${a.minutes}-min ${a.mode || "drive"}-time areas`;
+    case "buffer": return `Buffered by ${a.distance_m} m`;
+    case "spatial_join":
+      return a.keep === "non_matching"
+        ? `Selected features outside every area (the access gap): ${n}`
+        : `Selected features that ${a.predicate || "intersect"}: ${n}`;
+    case "filter_by_attribute": return `Kept where ${a.attribute} ${a.op} ${a.value}: ${n}`;
+    case "demographic_overlay": return `Overlaid ${a.value_field} onto the areas`;
+    case "nearest": return `Measured distance to the nearest destination`;
+    case "finish": return `Final answer ready`;
+    default: return step.tool;
+  }
+}
+
+function addTrace(container, trace) {
+  const det = document.createElement("details");
+  det.className = "trace";
+  det.open = true;
+  const sum = document.createElement("summary");
+  sum.textContent = "What the engine did";
+  det.appendChild(sum);
+  const ol = document.createElement("ol");
+  trace.forEach((step) => {
+    const li = document.createElement("li");
+    if (step.is_error) li.className = "err";
+    li.textContent = describeStep(step);
+    ol.appendChild(li);
+  });
+  det.appendChild(ol);
+  container.appendChild(det);
+}
+
+// --- map layers -------------------------------------------------------------
+
+function bboxOf(geojson) {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  const walk = (c) => {
+    if (typeof c[0] === "number") {
+      minX = Math.min(minX, c[0]); maxX = Math.max(maxX, c[0]);
+      minY = Math.min(minY, c[1]); maxY = Math.max(maxY, c[1]);
+    } else c.forEach(walk);
+  };
+  (geojson.features || []).forEach((f) => f.geometry && walk(f.geometry.coordinates));
+  return minX === Infinity ? null : [[minX, minY], [maxX, maxY]];
+}
+
+function addResultLayer(geojson, name, color) {
+  const id = `res_${state.seq++}`;
+  const sub = [`${id}_fill`, `${id}_line`, `${id}_pt`];
+  whenReady(() => {
+    map.addSource(id, { type: "geojson", data: geojson });
+    map.addLayer({ id: sub[0], type: "fill", source: id,
+      filter: ["==", ["geometry-type"], "Polygon"],
+      paint: { "fill-color": color, "fill-opacity": 0.28 } });
+    map.addLayer({ id: sub[1], type: "line", source: id,
+      filter: ["==", ["geometry-type"], "Polygon"],
+      paint: { "line-color": color, "line-width": 2 } });
+    map.addLayer({ id: sub[2], type: "circle", source: id,
+      filter: ["==", ["geometry-type"], "Point"],
+      paint: { "circle-color": color, "circle-radius": 6, "circle-stroke-color": "#fff", "circle-stroke-width": 1.5 } });
+    const bb = bboxOf(geojson);
+    if (bb) map.fitBounds(bb, { padding: 60, maxZoom: 12, duration: 600 });
+  });
+  const layer = { id, name, color, sub, visible: true };
+  state.layers.push(layer);
+  renderLayerList();
+  return layer;
+}
+
+function renderLayerList() {
+  els.layersPanel.hidden = state.layers.length === 0;
+  els.layers.innerHTML = "";
+  state.layers.forEach((layer) => {
+    const li = document.createElement("li");
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.checked = layer.visible;
+    cb.addEventListener("change", () => {
+      layer.visible = cb.checked;
+      const v = cb.checked ? "visible" : "none";
+      whenReady(() => layer.sub.forEach((s) => map.getLayer(s) && map.setLayoutProperty(s, "visibility", v)));
+    });
+    const sw = document.createElement("span");
+    sw.className = "swatch";
+    sw.style.background = layer.color;
+    const label = document.createElement("span");
+    label.textContent = layer.name;
+    li.append(cb, sw, label);
+    els.layers.appendChild(li);
+  });
+}
+
+// --- request flow -----------------------------------------------------------
+
+async function submitQuestion(question, endpoint) {
+  els.askButton.disabled = true;
+  els.demoButton.disabled = true;
+  const thinking = addThinking();
+  try {
+    const resp = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ question }),
+    });
+    thinking.remove();
+
+    if (!resp.ok) {
+      const detail = await resp.json().catch(() => ({}));
+      addMessage(
+        resp.status === 503
+          ? `Not configured: ${detail.detail || "backend unavailable"}. Try the sample question below.`
+          : `Request failed (${resp.status}).`,
+        "error"
+      );
+      return;
+    }
+
+    const data = await resp.json();
+    const color = PALETTE[state.layers.length % PALETTE.length];
+    const hasMap = data.geojson && (data.geojson.features || []).length > 0;
+
+    const msg = addMessage(data.explanation || "(no explanation)", "assistant", hasMap ? color : null);
+    if (data.trace && data.trace.length) addTrace(msg, data.trace);
+
+    if (hasMap) {
+      const count = data.geojson.features.length;
+      addResultLayer(data.geojson, `${trimName(question)} (${count})`, color);
+    } else if (data.finished === false) {
+      // model answered in prose without producing a map — already shown.
+    }
+  } catch (err) {
+    thinking.remove();
+    addMessage(`Network error: ${err.message}`, "error");
+  } finally {
+    els.askButton.disabled = false;
+    els.demoButton.disabled = false;
+  }
+}
+
+function trimName(q) {
+  return q.length > 28 ? q.slice(0, 27) + "…" : q;
+}
+
+els.form.addEventListener("submit", (e) => {
+  e.preventDefault();
+  const q = els.question.value.trim();
+  if (!q) return;
+  addMessage(q, "user");
+  els.question.value = "";
+  submitQuestion(q, "/ask");
+});
+
+const SAMPLE_Q = "Neighbourhoods >10 min from a pharmacy with above-average seniors";
+els.demoButton.addEventListener("click", () => {
+  addMessage(SAMPLE_Q, "user");
+  submitQuestion(SAMPLE_Q, "/ask/demo");
+});

--- a/GeoAsk/app/web/index.html
+++ b/GeoAsk/app/web/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>GeoAsk — ask a map</title>
+  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body>
+  <div id="app">
+    <aside id="sidebar">
+      <header id="brand">
+        <h1>GeoAsk</h1>
+        <p>Ask a spatial question in plain English. Get a map back.</p>
+      </header>
+
+      <div id="messages" aria-live="polite"></div>
+
+      <section id="layers-panel" hidden>
+        <h2>Layers</h2>
+        <ul id="layers"></ul>
+      </section>
+
+      <form id="ask-form" autocomplete="off">
+        <input
+          id="question"
+          type="text"
+          placeholder="e.g. neighbourhoods far from a pharmacy with many seniors"
+          aria-label="Your question"
+        />
+        <button type="submit" id="ask-button">Ask</button>
+      </form>
+      <button type="button" id="demo-button" class="linkish">
+        ▶ Try a sample question (no setup needed)
+      </button>
+    </aside>
+
+    <div id="map"></div>
+  </div>
+
+  <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/GeoAsk/app/web/styles.css
+++ b/GeoAsk/app/web/styles.css
@@ -1,0 +1,104 @@
+:root {
+  --bg: #ffffff;
+  --panel: #f7f8fa;
+  --panel-2: #eef1f5;
+  --text: #1a1f2b;
+  --muted: #5b6472;
+  --border: #dce1e8;
+  --accent: #2f6fed;
+  --accent-ink: #ffffff;
+  --user: #e7effe;
+  --error: #b23c3c;
+  --error-bg: #fbe9e9;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0e1116;
+    --panel: #151a22;
+    --panel-2: #1c2330;
+    --text: #e7ecf3;
+    --muted: #97a1b0;
+    --border: #2a3340;
+    --accent: #4c8bff;
+    --accent-ink: #0e1116;
+    --user: #1b2740;
+    --error: #ff8a8a;
+    --error-bg: #2a1a1c;
+  }
+}
+
+* { box-sizing: border-box; }
+html, body { height: 100%; margin: 0; }
+body {
+  font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+#app { display: flex; height: 100vh; }
+
+#sidebar {
+  width: 380px;
+  min-width: 320px;
+  display: flex;
+  flex-direction: column;
+  background: var(--panel);
+  border-right: 1px solid var(--border);
+}
+
+#brand { padding: 18px 20px 12px; border-bottom: 1px solid var(--border); }
+#brand h1 { margin: 0; font-size: 20px; letter-spacing: -0.01em; }
+#brand p { margin: 4px 0 0; color: var(--muted); font-size: 13px; }
+
+#messages { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 12px; }
+
+.msg { padding: 10px 12px; border-radius: 12px; max-width: 92%; white-space: pre-wrap; }
+.msg.user { align-self: flex-end; background: var(--user); }
+.msg.assistant { align-self: flex-start; background: var(--panel-2); }
+.msg.error { align-self: flex-start; background: var(--error-bg); color: var(--error); }
+.msg .swatch { display: inline-block; width: 10px; height: 10px; border-radius: 2px; margin-right: 6px; vertical-align: middle; }
+
+.trace { margin-top: 8px; border-top: 1px dashed var(--border); padding-top: 8px; }
+.trace summary { cursor: pointer; color: var(--muted); font-size: 13px; }
+.trace ol { margin: 8px 0 0; padding-left: 18px; }
+.trace li { margin: 3px 0; font-size: 13px; }
+.trace li.err { color: var(--error); }
+.trace code { background: var(--panel); padding: 0 4px; border-radius: 4px; font-size: 12px; }
+
+.thinking { color: var(--muted); font-style: italic; }
+.thinking::after { content: "…"; animation: dots 1.2s steps(4, end) infinite; }
+@keyframes dots { 0% { opacity: .3 } 50% { opacity: 1 } 100% { opacity: .3 } }
+
+#layers-panel { border-top: 1px solid var(--border); padding: 12px 16px; max-height: 26vh; overflow-y: auto; }
+#layers-panel h2 { margin: 0 0 8px; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+#layers { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+#layers li { display: flex; align-items: center; gap: 8px; font-size: 13px; }
+#layers input { accent-color: var(--accent); }
+#layers .swatch { width: 12px; height: 12px; border-radius: 3px; flex: none; }
+#layers .count { color: var(--muted); margin-left: auto; font-size: 12px; }
+
+#ask-form { display: flex; gap: 8px; padding: 12px 16px 4px; border-top: 1px solid var(--border); }
+#question {
+  flex: 1; padding: 10px 12px; border: 1px solid var(--border); border-radius: 10px;
+  background: var(--bg); color: var(--text); font-size: 14px;
+}
+#question:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+#ask-button {
+  padding: 10px 16px; border: none; border-radius: 10px; background: var(--accent);
+  color: var(--accent-ink); font-weight: 600; cursor: pointer;
+}
+#ask-button:disabled { opacity: .5; cursor: default; }
+
+.linkish {
+  background: none; border: none; color: var(--accent); cursor: pointer;
+  font-size: 13px; padding: 6px 16px 14px; text-align: left;
+}
+.linkish:disabled { opacity: .5; cursor: default; }
+
+#map { flex: 1; }
+
+@media (max-width: 720px) {
+  #app { flex-direction: column; }
+  #sidebar { width: 100%; height: 55vh; }
+  #map { height: 45vh; }
+}

--- a/GeoAsk/requirements.txt
+++ b/GeoAsk/requirements.txt
@@ -5,6 +5,9 @@ pydantic>=2.7
 shapely>=2.0
 pyproj>=3.6
 
+# AI orchestration (Phase 2) — LLM function calling
+anthropic>=0.117
+
 # Testing
 pytest>=8.0
 httpx>=0.27

--- a/GeoAsk/tests/test_frontend.py
+++ b/GeoAsk/tests/test_frontend.py
@@ -1,0 +1,50 @@
+"""Frontend serving + the no-config demo endpoint.
+
+These run with no API key and no database, so the whole Phase 3 surface is
+covered in CI: the page is served, its assets resolve, and /ask/demo returns a
+real orchestrated result the UI can render.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_index_page_is_served():
+    resp = client.get("/")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "GeoAsk" in body
+    assert 'id="map"' in body
+    assert 'id="ask-form"' in body
+
+
+def test_static_assets_resolve():
+    for path in ("/static/app.js", "/static/styles.css"):
+        assert client.get(path).status_code == 200
+
+
+def test_demo_endpoint_returns_orchestrated_result():
+    resp = client.post("/ask/demo")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["finished"] is True
+    # The canned access-gap plan yields exactly the far-senior tract.
+    names = [f["properties"]["tract"] for f in data["geojson"]["features"]]
+    assert names == ["far-senior"]
+    # Trace is the transparency panel: the full chain, ending in finish.
+    tools = [s["tool"] for s in data["trace"]]
+    assert tools == ["load_pois", "isochrone", "load_tracts", "spatial_join",
+                     "filter_by_attribute", "finish"]
+    assert "drive-time" in data["explanation"]
+
+
+def test_demo_geojson_is_renderable():
+    data = client.post("/ask/demo").json()
+    feat = data["geojson"]["features"][0]
+    assert feat["geometry"]["type"] == "Polygon"
+    assert feat["geometry"]["coordinates"]

--- a/GeoAsk/tests/test_orchestration.py
+++ b/GeoAsk/tests/test_orchestration.py
@@ -1,0 +1,160 @@
+"""Orchestration-layer tests, driven by a scripted fake LLM (no API key).
+
+The fake plays a fixed list of turns, each a list of (tool_name, args) calls,
+exactly as the real model's tool_use blocks would arrive. Because layer handles
+are assigned deterministically (layer_1, layer_2, …), the scripts can reference
+them — the same way the model references the handles it got back.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from app.orchestration import InMemoryDataSource, ask
+
+
+# --- fake LLM client ---------------------------------------------------------
+
+def _tool_use(call_id, name, args):
+    return SimpleNamespace(type="tool_use", id=call_id, name=name, input=args)
+
+
+class ScriptedLLM:
+    """Plays scripted turns; records the messages it is handed each call."""
+
+    def __init__(self, turns):
+        self._turns = turns
+        self._i = 0
+        self.seen_messages = []
+
+    def respond(self, system, tools, messages):
+        self.seen_messages.append(messages)
+        turn = self._turns[self._i]
+        self._i += 1
+        content = [_tool_use(f"t{self._i}_{j}", name, args) for j, (name, args) in enumerate(turn)]
+        return SimpleNamespace(content=content, stop_reason="tool_use")
+
+
+# --- fixtures ----------------------------------------------------------------
+
+LON, LAT = -122.68, 45.52
+
+
+def _point(lon, lat, **props):
+    return {"type": "Feature", "geometry": {"type": "Point", "coordinates": [lon, lat]}, "properties": props}
+
+
+def _tract(name, x0, y0, size, **props):
+    ring = [[x0, y0], [x0 + size, y0], [x0 + size, y0 + size], [x0, y0 + size], [x0, y0]]
+    return {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [ring]}, "properties": {"tract": name, **props}}
+
+
+@pytest.fixture
+def source():
+    pharmacies = {"type": "FeatureCollection", "features": [_point(LON, LAT, name="Central")]}
+    tracts = {
+        "type": "FeatureCollection",
+        "features": [
+            _tract("near-young", LON - 0.01, LAT - 0.01, 0.02, pct_senior=8.0),
+            _tract("far-senior", LON + 0.20, LAT, 0.02, pct_senior=27.0),
+            _tract("far-young", LON + 0.20, LAT + 0.03, 0.02, pct_senior=9.0),
+        ],
+    }
+    return InMemoryDataSource({"pharmacy": pharmacies}, tracts)
+
+
+# --- the headline test: a full access-gap chain ------------------------------
+
+def test_full_access_gap_chain(source):
+    turns = [
+        [("load_pois", {"category": "pharmacy"})],                                  # layer_1
+        [("isochrone", {"layer_id": "layer_1", "minutes": 10, "mode": "drive"})],   # layer_2
+        [("load_tracts", {})],                                                      # layer_3
+        [("spatial_join", {"target_layer_id": "layer_3", "join_layer_id": "layer_2",
+                            "predicate": "intersects", "keep": "non_matching"})],    # layer_4
+        [("filter_by_attribute", {"layer_id": "layer_4", "attribute": "pct_senior",
+                                   "op": ">", "value": 15})],                        # layer_5
+        [("finish", {"layer_id": "layer_5", "explanation": "Found pharmacies, built "
+                     "10-min drive areas, took tracts outside them, kept the senior ones."})],
+    ]
+    result = ask("neighbourhoods >10 min from a pharmacy with many seniors", ScriptedLLM(turns), source)
+
+    assert result.finished
+    names = [f["properties"]["tract"] for f in result.geojson["features"]]
+    assert names == ["far-senior"]
+    assert "drive" in result.explanation
+    # The trace is the transparency panel: one step per executed tool + finish.
+    assert [s.tool for s in result.trace] == [
+        "load_pois", "isochrone", "load_tracts", "spatial_join", "filter_by_attribute", "finish"
+    ]
+
+
+# --- guardrails --------------------------------------------------------------
+
+def test_error_is_reported_then_repaired(source):
+    turns = [
+        [("load_pois", {"category": "pharmacy"})],                       # layer_1
+        [("buffer", {"layer_id": "layer_1", "distance_m": -5})],          # error, no layer
+        [("buffer", {"layer_id": "layer_1", "distance_m": 500})],         # layer_2 (repaired)
+        [("finish", {"layer_id": "layer_2", "explanation": "buffered"})],
+    ]
+    result = ask("within 500m of a pharmacy", ScriptedLLM(turns), source)
+    assert result.finished
+    errored = [s for s in result.trace if s.is_error]
+    assert len(errored) == 1 and "distance_m must be positive" in errored[0].result["error"]
+
+
+def test_finish_with_bad_layer_is_rejected_not_crashed(source):
+    turns = [
+        [("load_pois", {"category": "pharmacy"})],                        # layer_1
+        [("finish", {"layer_id": "layer_99", "explanation": "oops"})],    # bad handle
+        [("finish", {"layer_id": "layer_1", "explanation": "ok"})],       # valid
+    ]
+    result = ask("show pharmacies", ScriptedLLM(turns), source)
+    assert result.finished
+    assert len(result.geojson["features"]) == 1
+
+
+def test_unknown_layer_reference_is_an_error(source):
+    turns = [
+        [("buffer", {"layer_id": "layer_1", "distance_m": 100})],  # nothing loaded yet
+        [("load_pois", {"category": "pharmacy"})],                 # now layer_1 exists
+        [("finish", {"layer_id": "layer_1", "explanation": "done"})],
+    ]
+    result = ask("q", ScriptedLLM(turns), source)
+    assert result.trace[0].is_error
+    assert "no such layer" in result.trace[0].result["error"]
+
+
+# --- the design rule: the model never receives raw geometry ------------------
+
+def test_llm_never_sees_coordinates(source):
+    turns = [
+        [("load_pois", {"category": "pharmacy"})],
+        [("finish", {"layer_id": "layer_1", "explanation": "done"})],
+    ]
+    llm = ScriptedLLM(turns)
+    ask("show pharmacies", llm, source)
+
+    # Everything handed to the LLM (tool results included) must be geometry-free.
+    blob = json.dumps(_serialisable(llm.seen_messages))
+    assert "coordinates" not in blob
+    assert "feature_count" in blob  # it did get the summary
+
+
+def _serialisable(messages):
+    """Keep only what actually carries data to the model: the initial question
+    string and the tool_result blocks. Assistant turns hold SimpleNamespace
+    blocks (the fake's stand-in for SDK objects) and aren't model *input*."""
+    out = []
+    for msg_list in messages:
+        for m in msg_list:
+            content = m.get("content")
+            if isinstance(content, str):
+                out.append(content)
+            elif isinstance(content, list):
+                out.extend(b for b in content if isinstance(b, dict) and b.get("type") == "tool_result")
+    return out


### PR DESCRIPTION
Builds on the GeoAsk foundation merged in #16 (Phase 0 data layer + Phase 1 tested spatial primitives). This PR adds the two layers that turn the engine into a usable product.

## Phase 2 — AI orchestration (`app/orchestration/`)
Translates a plain-English question into a validated chain of primitive calls via LLM function calling (Claude, adaptive thinking). Pipeline: **parse → plan → execute → assemble**.

- **The LLM never touches raw data** — enforced structurally by a *layer store*: every tool takes/returns opaque layer handles plus a geometry-free summary (feature count, property names). The model chains steps by passing handles; it never sees a coordinate.
- **Guardrails** — the executor turns any primitive `ValueError` (bad distance, unknown operator, empty layer, missing handle) into an `is_error` tool result the model repairs on its next turn, instead of failing the request.
- **Transparency trace** — every tool call and its result recorded in order (the "what the AI did" panel).
- **Injectable boundaries** — both the LLM (`LLMClient`) and data source (`DataSource`) are protocols, so the whole loop is tested with a scripted fake model + in-memory source, no API key or DB.
- Exposed as `POST /ask`.

## Phase 3 — Map & chat frontend (`app/web/`)
A self-contained MapLibre GL map + chat page served by FastAPI at `/`.

- Answer renders as a **toggleable map layer**; the model's explanation appears in chat; a **transparency panel** lists the steps from the `/ask` trace.
- Session state keeps each result as its own layer (ask → refine → compare).
- **Degrades gracefully** if the map library can't load — answers and the trace still work, only the map canvas is omitted.
- **No-config `/ask/demo`** runs the real orchestrator over in-memory sample data via a scripted planner, so the UI works and is CI-tested with no API key or database.

## Testing
- 44 tests pass (adds 5 orchestration + 4 frontend tests to the existing suite), including a full scripted access-gap chain, error-repair, bad-handle rejection, the no-raw-geometry invariant, the served page, the demo pipeline, and live-PostGIS integration (auto-skips without `DATABASE_URL`).
- Frontend verified end-to-end in a headless browser (chat, explanation, 6-step trace, layer list).

## Notes / honest caveats
- The orchestration *logic* is fully tested via the scripted client; a live Claude call isn't exercised here (no API key in the build environment). `/ask` returns a clean 503 rather than pretending when `ANTHROPIC_API_KEY` or `DATABASE_URL` is missing.
- Frontend uses a self-contained page (MapLibre from CDN) rather than a React build — no toolchain, served directly by the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUj97HpKXfyGFXSbjJbVZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUj97HpKXfyGFXSbjJbVZE)_