### PR TITLE
GeoAsk Phase 5: validation harness — accuracy audit vs. manual GIS

### DIFF
--- a/GeoAsk/README.md
+++ b/GeoAsk/README.md
@@ -185,8 +185,8 @@ fetch of Overture/OSM POIs and Census/ACS tracts for a pilot bbox.
 - **Phase 1 — Spatial primitives:** ✅ implemented, tested, exposed via API; isochrone backed by a routing engine
 - **Phase 2 — AI orchestration:** ✅ parse → plan → execute → assemble over the primitives, layer-handle isolation, guardrails, transparency trace, `POST /ask`
 - **Phase 3 — Map & chat frontend:** ✅ served at `/` — map + chat + toggleable layers + transparency panel, graceful offline degradation, and a no-config `/ask/demo`
-- **Phase 4 — MVP (Access-Gap Finder):** ✅ scoped to access-gap done well — realistic sample, sample-question chips, engine-grounded result summary, a 15-phrasing corpus + live-eval harness, and deploy-as-one-URL via Docker (49 tests + 1 skipped live eval)
-- **Phase 5 — Pilot & validation:** next — run with real gov/planning users, accuracy audit vs. manual GIS (the `evals/` corpus is the seed), measure query success rate and time-to-answer
+- **Phase 4 — MVP (Access-Gap Finder):** ✅ scoped to access-gap done well — realistic sample, sample-question chips, engine-grounded result summary, a 15-phrasing corpus + live-eval harness, and deploy-as-one-URL via Docker
+- **Phase 5 — Pilot & validation:** ✅ *harness* — an accuracy audit (`evals/audit.py`) that compares the AI's maps to a deterministic manual-GIS baseline (`evals/ground_truth.py`), measures time-to-answer, and gates on the ≥80% bar, with the methodology documented (`evals/README.md`). Running the pilot itself needs a live model, regional data, and real users (54 tests + 1 skipped live eval)
 
 The `demo_access_gap.py` trace is a preview of the transparency panel: it prints
 exactly what the engine did at each step, which the plan calls non-negotiable

--- a/GeoAsk/app/orchestration/llm.py
+++ b/GeoAsk/app/orchestration/llm.py
@@ -65,6 +65,10 @@ class ScriptedClient:
         self._ns = SimpleNamespace
 
     def respond(self, system, tools, messages):
+        # A fresh conversation (only the user turn present) replays from the top,
+        # so one instance can drive many independent questions.
+        if len(messages) == 1:
+            self._i = 0
         turn = self._turns[self._i]
         self._i += 1
         content = [

--- a/GeoAsk/evals/README.md
+++ b/GeoAsk/evals/README.md
@@ -1,0 +1,65 @@
+# Validation & accuracy audit (Phase 5)
+
+Phase 5 asks: does GeoAsk work for someone who isn't you? The acceptance bar is
+**≥80% of realistic user questions return a correct, useful map**, with a
+documented comparison against manual GIS analysis. This directory is the harness
+that measures it.
+
+## The pieces
+
+| File | What it is |
+|---|---|
+| `phrasings.py` | 15 real phrasings of the one MVP question (access-gap), + a scorer for the access-gap invariant |
+| `ground_truth.py` | The **manual-GIS baseline** — the known-correct answer per question, computed deterministically from the tested primitives (no LLM) |
+| `audit.py` | Runs the corpus through the model, times each query, compares to the baseline, reports success rate + time-to-answer + where it breaks |
+| `run.py` | Lighter pass/fail runner over the invariant scorer |
+
+## How accuracy is measured
+
+The audit compares two things over the same sample data:
+
+1. **Manual baseline** (`ground_truth.manual_access_gap`) — an analyst's correct
+   chain, encoded: isochrone → spatial-join (keep non-matching) → optional
+   above-average-senior filter. Deterministic, LLM-free. This is the "manual GIS
+   analysis" the plan says to spot-check against.
+2. **The AI's answer** — what the orchestrator's plan actually produced.
+
+A query is **correct** when the AI's tract set exactly matches the baseline. A
+looser **invariant** check (a *reachable* neighbourhood must never appear in an
+access-gap answer) catches the failure that would most mislead a user, and is
+robust to defensible modelling choices (10 vs 12 minutes, threshold).
+
+`time-to-answer` is measured per query so the pilot can compare it against the
+manual workflow (minutes-to-hours in a desktop GIS).
+
+## Running it
+
+```bash
+# Audit the live model (the pilot run)
+ANTHROPIC_API_KEY=... python -m evals.audit
+
+# Offline: print the manual-GIS reference answers the pilot audits against
+python -m evals.audit
+```
+
+`audit.py` exits non-zero if accuracy is below the 80% bar, so it can gate a
+release.
+
+## Manual-GIS reference answers (sample data)
+
+Generated offline from `ground_truth.py` over the demo sample (2 pharmacies,
+7 tracts). These are the correct maps; the audit measures how often the model
+reproduces them.
+
+| Question type | Correct answer |
+|---|---|
+| Access gap, no demographic filter | Centennial, Hazelwood, Pleasant Vly, Powellhurst |
+| Access gap, above-average seniors | Hazelwood, Pleasant Vly, Powellhurst |
+
+## What's automated vs. what needs the pilot
+
+The harness — baseline, scoring, timing, report, acceptance gate — is code and is
+unit-tested in CI. What it can't manufacture is the pilot itself: a live model
+(API key), real POI/Census data for the region, and 2–3 real gov/planning users
+asking their own questions. Point the harness at those and it produces the
+Phase 5 scorecard.

--- a/GeoAsk/evals/audit.py
+++ b/GeoAsk/evals/audit.py
@@ -1,0 +1,126 @@
+"""Accuracy audit + measurement harness for the pilot (Phase 5).
+
+Runs the phrasing corpus through an orchestrator, times each query, compares the
+AI's answer to the deterministic manual-GIS baseline (``ground_truth``), and
+reports the metrics the plan calls for: query success rate, time-to-answer, and
+where it breaks. The plan's acceptance bar is ≥80% correct maps.
+
+    ANTHROPIC_API_KEY=... python -m evals.audit      # audit the live model
+    python -m evals.audit                            # offline: print the
+                                                     # manual-baseline reference
+
+The scoring and report functions are pure so they're unit-tested without a model
+(``tests/test_audit.py``); the live audit is the pilot run.
+"""
+
+from __future__ import annotations
+
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+
+from app.orchestration import ask
+from app.orchestration.demo import _sample_source
+from app.orchestration.llm import LLMClient, default_client
+
+from .ground_truth import manual_access_gap
+from .phrasings import PHRASINGS, score
+
+ACCEPTANCE = 0.80  # ≥80% of realistic questions return a correct, useful map
+
+
+@dataclass
+class QueryOutcome:
+    question: str
+    expected: set[str]
+    actual: set[str] | None
+    correct: bool          # exact match against the manual baseline
+    invariant_ok: bool     # the access-gap invariant held (looser)
+    seconds: float
+    note: str
+
+
+def reference_table(source) -> list[tuple[str, set[str]]]:
+    """The manual-GIS reference answer for every phrasing — generatable with no
+    model, this is the documented baseline the pilot audits against."""
+    return [(m["q"], manual_access_gap(source, seniors=m["expects_seniors"])) for m in PHRASINGS]
+
+
+def run_audit(client: LLMClient, source) -> list[QueryOutcome]:
+    outcomes = []
+    for m in PHRASINGS:
+        expected = manual_access_gap(source, seniors=m["expects_seniors"])
+        t0 = time.perf_counter()
+        result = ask(m["q"], client, source)
+        seconds = time.perf_counter() - t0
+        actual = (
+            {f["properties"].get("tract") for f in result.geojson["features"]}
+            if result.geojson else None
+        )
+        ok, note = score(m, result)
+        outcomes.append(QueryOutcome(m["q"], expected, actual, actual == expected, ok, seconds, note))
+    return outcomes
+
+
+def summarize(outcomes: list[QueryOutcome]) -> dict:
+    n = len(outcomes)
+    times = [o.seconds for o in outcomes]
+    correct = sum(o.correct for o in outcomes)
+    return {
+        "n": n,
+        "accuracy": correct / n if n else 0.0,
+        "invariant_rate": sum(o.invariant_ok for o in outcomes) / n if n else 0.0,
+        "mean_seconds": statistics.mean(times) if times else 0.0,
+        "median_seconds": statistics.median(times) if times else 0.0,
+        "passes_acceptance": (correct / n if n else 0.0) >= ACCEPTANCE,
+        "failures": [(o.question, _diff_note(o)) for o in outcomes if not o.correct],
+    }
+
+
+def _diff_note(o: "QueryOutcome") -> str:
+    got = sorted(o.actual) if o.actual is not None else None
+    return f"expected {sorted(o.expected)}, got {got}"
+
+
+def render_report(outcomes: list[QueryOutcome], summary: dict) -> str:
+    pct = lambda x: f"{100 * x:.0f}%"
+    lines = [
+        "# GeoAsk accuracy audit",
+        "",
+        f"- Queries: **{summary['n']}**",
+        f"- Correct maps (exact match vs manual baseline): **{pct(summary['accuracy'])}**",
+        f"- Access-gap invariant held: **{pct(summary['invariant_rate'])}**",
+        f"- Time-to-answer: mean **{summary['mean_seconds']:.2f}s**, median **{summary['median_seconds']:.2f}s**",
+        f"- Acceptance (≥{pct(ACCEPTANCE)} correct): **{'PASS' if summary['passes_acceptance'] else 'FAIL'}**",
+        "",
+        "| # | Question | Correct | Invariant | Time (s) |",
+        "|---|---|:---:|:---:|---:|",
+    ]
+    for i, o in enumerate(outcomes, 1):
+        lines.append(f"| {i} | {o.question} | {'✓' if o.correct else '✗'} | "
+                     f"{'✓' if o.invariant_ok else '✗'} | {o.seconds:.2f} |")
+    if summary["failures"]:
+        lines += ["", "## Where it breaks", ""]
+        lines += [f"- **{q}** — {note}" for q, note in summary["failures"]]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    source = _sample_source()
+    client = default_client()
+    if client is None:
+        print("No live model (set ANTHROPIC_API_KEY). Manual-GIS reference answers:\n")
+        for i, (q, expected) in enumerate(reference_table(source), 1):
+            print(f"{i:2}. {q}\n    -> {sorted(expected)}")
+        print("\nRun with ANTHROPIC_API_KEY set to audit the model against these.")
+        return 2
+
+    outcomes = run_audit(client, source)
+    summary = summarize(outcomes)
+    print(render_report(outcomes, summary))
+    return 0 if summary["passes_acceptance"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/GeoAsk/evals/ground_truth.py
+++ b/GeoAsk/evals/ground_truth.py
@@ -1,0 +1,46 @@
+"""The "manual GIS" baseline — deterministic reference answers.
+
+Phase 5's accuracy audit spot-checks the AI's maps against manual GIS analysis.
+This module *is* that manual analysis, encoded: it chains the tested primitives
+the way a competent analyst would, with no LLM, to compute the known-correct
+answer for each question type. The audit then measures how often the AI's plan
+reproduces this reference.
+
+Computing the baseline from the same validated primitives the AI orchestrates is
+the point: the primitives are the ground-truth spatial operations (Phase 1,
+tested against known outputs); what's under test in the pilot is whether the
+model *plans the right chain*, not whether the operations are correct.
+"""
+
+from __future__ import annotations
+
+from app.spatial import filter_by_attribute, isochrone, spatial_join
+from app.spatial.geo import features_of
+
+
+def _mean_pct_senior(tracts: dict) -> float:
+    vals = [f["properties"]["pct_senior"] for f in features_of(tracts)
+            if f.get("properties", {}).get("pct_senior") is not None]
+    return sum(vals) / len(vals) if vals else 0.0
+
+
+def manual_access_gap(
+    source,
+    *,
+    seniors: bool,
+    minutes: float = 10,
+    mode: str = "drive",
+) -> set[str]:
+    """The reference set of tract names for an access-gap question.
+
+    ``seniors=True`` additionally keeps only tracts whose senior share is above
+    the mean across all tracts — the natural reading of "above-average seniors".
+    """
+    pharmacies = source.load_pois("pharmacy")
+    areas = isochrone(pharmacies, minutes, mode)
+    tracts = source.load_tracts()
+    gap = spatial_join(tracts, areas, "intersects", "non_matching")
+    if seniors:
+        threshold = _mean_pct_senior(tracts)
+        gap = filter_by_attribute(gap, "pct_senior", ">", threshold)
+    return {f["properties"].get("tract") for f in features_of(gap)}

--- a/GeoAsk/tests/test_audit.py
+++ b/GeoAsk/tests/test_audit.py
@@ -1,0 +1,59 @@
+"""Ground-truth baseline + audit harness tests — all offline (no model)."""
+
+from __future__ import annotations
+
+from app.orchestration.demo import _PLAN, _sample_source
+from app.orchestration.llm import ScriptedClient
+from evals.audit import ACCEPTANCE, render_report, run_audit, summarize
+from evals.ground_truth import manual_access_gap
+
+
+# --- the manual-GIS baseline ------------------------------------------------
+
+def test_baseline_access_gap_is_all_far_tracts():
+    gap = manual_access_gap(_sample_source(), seniors=False)
+    assert gap == {"Pleasant Vly", "Powellhurst", "Centennial", "Hazelwood"}
+
+
+def test_baseline_senior_filter_drops_the_young_far_tract():
+    gap = manual_access_gap(_sample_source(), seniors=True)
+    # Centennial is far but young (9% < mean) — excluded.
+    assert gap == {"Pleasant Vly", "Powellhurst", "Hazelwood"}
+
+
+# --- the audit harness ------------------------------------------------------
+
+def test_audit_against_scripted_planner_scores_and_reports():
+    # The demo planner always applies the senior filter, so it's right on the
+    # senior phrasings and wrong on the plain-access-gap ones — the harness
+    # should detect exactly that.
+    outcomes = run_audit(ScriptedClient(_PLAN), _sample_source())
+    summary = summarize(outcomes)
+
+    assert summary["n"] == 15
+    assert summary["invariant_rate"] == 1.0          # never leaks a reachable tract
+    assert 0.0 < summary["accuracy"] < 1.0           # right on some, wrong on others
+    assert summary["passes_acceptance"] is (summary["accuracy"] >= ACCEPTANCE)
+    # Every failure is a plain-access-gap phrasing missing the young far tract.
+    for _, note in summary["failures"]:
+        assert "Centennial" in note
+
+
+def test_report_renders_key_metrics():
+    outcomes = run_audit(ScriptedClient(_PLAN), _sample_source())
+    report = render_report(outcomes, summarize(outcomes))
+    assert "# GeoAsk accuracy audit" in report
+    assert "Correct maps" in report
+    assert "Time-to-answer" in report
+    assert "Where it breaks" in report
+
+
+def test_summarize_handles_all_correct():
+    # A planner matching the baseline on every query passes acceptance at 100%.
+    outcomes = run_audit(ScriptedClient(_PLAN), _sample_source())
+    for o in outcomes:
+        o.correct = True
+    summary = summarize(outcomes)
+    assert summary["accuracy"] == 1.0
+    assert summary["passes_acceptance"] is True
+    assert summary["failures"] == []


### PR DESCRIPTION
Builds on Phases 0–4 (merged in #16, #17, #18). Phase 5 is the pilot & validation phase. Running the pilot itself needs a live model, regional data, and real gov/planning users — none of which live in code — so this PR delivers the **validation harness** that makes the pilot runnable and gives the plan's acceptance bar (≥80% correct maps) something concrete to measure.

## What's in this PR

**Manual-GIS baseline (`evals/ground_truth.py`).** The plan says to spot-check AI results against manual GIS analysis. This encodes that manual analysis: it chains the tested primitives the way a competent analyst would (isochrone → spatial-join keep-non-matching → optional above-average-senior filter), deterministically, with no LLM. It's the known-correct answer the AI is audited against.

**Accuracy audit + measurement (`evals/audit.py`).** Runs the 15-phrasing corpus through the orchestrator and reports the metrics the plan calls for:
- **Success rate** — exact match against the manual baseline, plus a looser access-gap invariant (a *reachable* neighbourhood must never appear) that's robust to defensible modelling choices.
- **Time-to-answer** — per-query timing, so the pilot can compare against the manual desktop-GIS workflow.
- **Where it breaks** — the failing questions with an expected-vs-got diff.
- **Acceptance gate** — exits non-zero below the ≥80% bar, so it can gate a release.

Runs live with `ANTHROPIC_API_KEY` (the pilot run); prints the manual-baseline reference table offline.

**Methodology doc (`evals/README.md`).** The "documented accuracy vs. manual workflow" deliverable — how accuracy is measured, the reference answers, and what's automated vs. what the human pilot must bring.

**Offline-demonstrable.** `ScriptedClient` now replays per conversation, so the harness is unit-tested end-to-end against the demo planner with no model. It correctly scores that planner at 53% and flags exactly the seven plain-access-gap phrasings it gets wrong (it always applies the senior filter, dropping the far-but-young tract) — proving the harness detects real failure modes.

## Testing
- **54 tests pass** (+1 skipped live eval), including the baseline sets, the audit scoring/report logic, and live-PostGIS integration (auto-skips without `DATABASE_URL`).

## Honest scope note
This is the Phase 5 *harness*, not a Phase 5 sign-off. The plan's "done" for this phase is ≥80% measured over real users' questions with a documented accuracy comparison — which requires a live model, real POI/Census data for a pilot region, and 2–3 real users. Point this harness at those and it produces the scorecard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUj97HpKXfyGFXSbjJbVZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUj97HpKXfyGFXSbjJbVZE)_