### PR TITLE
GeoAsk MVP hardening: accessibility, one-tap refine, per-query cost tracking

### DIFF
--- a/GeoAsk/README.md
+++ b/GeoAsk/README.md
@@ -147,8 +147,20 @@ The frontend is designed for a non-technical user, not a power user:
 - **Answers in plain language** — every map result is also stated in words
   ("Neighbourhoods: Pleasant Vly (27% seniors), Powellhurst (19%), Hazelwood
   (24%)"), so you don't have to read a choropleth.
+- **Refine in one tap** — after an answer, quick refinements ("only ≥20%
+  seniors", "widen to a 15-minute drive") re-ask with the added constraint and
+  drop the result in as a new toggleable layer — the plan's "now only show ones
+  with >20% seniors" loop.
 - **Friendly dead-ends** — out-of-scope questions, empty results, and an
   unconfigured backend get a helpful nudge toward what works, never a raw error.
+- **Accessible** — landmark roles (log / region / group), labelled layer
+  toggles, keyboard focus rings on every control, a status-announced busy
+  indicator, and `prefers-reduced-motion` support.
+
+Each answer also shows its **per-query LLM cost** (tokens + estimated USD) — the
+plan flags cost as a risk to track, so the orchestrator sums token usage across
+the agent loop and returns it on every `/ask` response (the scripted demo shows
+zero, since it uses no model).
 
 Because a live map needs an API key and database, there's a **no-config demo**:
 the **sample-question chips** (and `POST /ask/demo`) run the real orchestrator

--- a/GeoAsk/app/orchestration/__init__.py
+++ b/GeoAsk/app/orchestration/__init__.py
@@ -5,7 +5,7 @@ LLM function calling. The model only ever calls the validated tools and only
 ever sees layer handles + summaries, never raw geometry.
 """
 
-from .orchestrator import AskResult, Clarification, TraceStep, ask
+from .orchestrator import AskResult, Clarification, TraceStep, Usage, ask
 from .sources import DataSource, InMemoryDataSource, PostgisDataSource
 
 __all__ = [
@@ -13,6 +13,7 @@ __all__ = [
     "AskResult",
     "Clarification",
     "TraceStep",
+    "Usage",
     "DataSource",
     "InMemoryDataSource",
     "PostgisDataSource",

--- a/GeoAsk/app/orchestration/demo.py
+++ b/GeoAsk/app/orchestration/demo.py
@@ -83,5 +83,24 @@ def run_demo() -> AskResult:
     return ask("sample question", ScriptedClient(_PLAN), _sample_source())
 
 
+# A refinement of the gap result: tighten the senior threshold to 20% — narrows
+# the 3 gap tracts to 2 (Powellhurst at 19% drops out).
+_REFINE_PLAN: list[list[tuple[str, dict[str, Any]]]] = [
+    [("load_pois", {"category": "pharmacy"})],
+    [("isochrone", {"layer_id": "layer_1", "minutes": 10, "mode": "drive"})],
+    [("load_tracts", {})],
+    [("spatial_join", {"target_layer_id": "layer_3", "join_layer_id": "layer_2",
+                       "predicate": "intersects", "keep": "non_matching"})],
+    [("filter_by_attribute", {"layer_id": "layer_4", "attribute": "pct_senior", "op": ">", "value": 20})],
+    [("finish", {"layer_id": "layer_5", "explanation":
+                 "Refined to neighbourhoods where seniors are more than 20% of the "
+                 "population — a stricter cut of the same access gap."})],
+]
+
+
 def run_clarify_demo() -> AskResult:
     return ask("underserved areas", ScriptedClient(_CLARIFY_PLAN), _sample_source())
+
+
+def run_refine_demo() -> AskResult:
+    return ask("only the ones with more than 20% seniors", ScriptedClient(_REFINE_PLAN), _sample_source())

--- a/GeoAsk/app/orchestration/llm.py
+++ b/GeoAsk/app/orchestration/llm.py
@@ -16,6 +16,21 @@ from typing import Any, Protocol
 
 MODEL = "claude-opus-4-8"
 
+# USD per 1M tokens (input, output). Kept here so cost tracking has one source of
+# truth; update when pricing changes. The plan calls out LLM cost as a risk to
+# track per query from Phase 2 on.
+PRICING = {
+    "claude-opus-4-8": (5.0, 25.0),
+    "claude-sonnet-5": (3.0, 15.0),
+    "claude-haiku-4-5": (1.0, 5.0),
+}
+
+
+def estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
+    """Rough USD cost for a query's token usage (excludes cache discounts)."""
+    in_rate, out_rate = PRICING.get(model, PRICING[MODEL])
+    return input_tokens / 1e6 * in_rate + output_tokens / 1e6 * out_rate
+
 
 class LLMClient(Protocol):
     def respond(
@@ -34,6 +49,7 @@ class AnthropicClient:
 
         self._client = anthropic.Anthropic()  # resolves ANTHROPIC_API_KEY / profile
         self._model = model
+        self.model = model  # public, for cost attribution
         self._max_tokens = max_tokens
 
     def respond(self, system, tools, messages):

--- a/GeoAsk/app/orchestration/orchestrator.py
+++ b/GeoAsk/app/orchestration/orchestrator.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .layers import LayerStore
-from .llm import LLMClient
+from .llm import MODEL, LLMClient, estimate_cost
 from .sources import DataSource
 from .tools import TOOL_SCHEMAS, ToolExecutor
 
@@ -84,12 +84,22 @@ class Clarification:
 
 
 @dataclass
+class Usage:
+    """Per-query LLM accounting, summed across the agent loop's turns."""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    turns: int = 0
+    est_cost_usd: float = 0.0
+
+
+@dataclass
 class AskResult:
     geojson: dict[str, Any] | None
     explanation: str
     trace: list[TraceStep] = field(default_factory=list)
     finished: bool = False
     clarification: Clarification | None = None
+    usage: Usage | None = None
 
 
 def ask(
@@ -103,27 +113,40 @@ def ask(
     executor = ToolExecutor(store, source)
     messages: list[dict[str, Any]] = [{"role": "user", "content": question}]
     trace: list[TraceStep] = []
+    tally = {"input": 0, "output": 0, "turns": 0}
+
+    def finalize(result: AskResult) -> AskResult:
+        model = getattr(client, "model", MODEL)
+        result.usage = Usage(
+            input_tokens=tally["input"],
+            output_tokens=tally["output"],
+            turns=tally["turns"],
+            est_cost_usd=round(estimate_cost(model, tally["input"], tally["output"]), 6),
+        )
+        return result
 
     for _ in range(max_turns):
         response = client.respond(SYSTEM_PROMPT, TOOL_SCHEMAS, messages)
+        tally["turns"] += 1
+        _accumulate(tally, getattr(response, "usage", None))
         messages.append({"role": "assistant", "content": response.content})
 
         tool_uses = [b for b in response.content if getattr(b, "type", None) == "tool_use"]
         if not tool_uses:
             # Model answered in prose without producing a map.
-            return AskResult(
+            return finalize(AskResult(
                 geojson=None,
                 explanation=_text_of(response.content),
                 trace=trace,
                 finished=False,
-            )
+            ))
 
         tool_results = []
         for block in tool_uses:
             if block.name == "clarify":
                 # Stop and hand a guided follow-up back to the user instead of
                 # guessing. This is a terminal state for the turn.
-                return AskResult(
+                return finalize(AskResult(
                     geojson=None,
                     explanation=block.input.get("question", ""),
                     trace=trace,
@@ -132,7 +155,7 @@ def ask(
                         question=block.input.get("question", ""),
                         options=list(block.input.get("options", [])),
                     ),
-                )
+                ))
 
             if block.name == "finish":
                 layer_id = block.input.get("layer_id")
@@ -145,7 +168,7 @@ def ask(
                     tool_results.append(_error_result(block.id, f"no such layer: {layer_id}"))
                     continue
                 trace.append(TraceStep("finish", dict(block.input), {"layer_id": layer_id}, False))
-                return AskResult(geojson=geojson, explanation=explanation, trace=trace, finished=True)
+                return finalize(AskResult(geojson=geojson, explanation=explanation, trace=trace, finished=True))
 
             result, is_error = executor.execute(block.name, block.input)
             trace.append(TraceStep(block.name, dict(block.input), result, is_error))
@@ -161,12 +184,21 @@ def ask(
         if tool_results:
             messages.append({"role": "user", "content": tool_results})
 
-    return AskResult(
+    return finalize(AskResult(
         geojson=None,
         explanation="Stopped: the plan did not converge within the step budget.",
         trace=trace,
         finished=False,
-    )
+    ))
+
+
+def _accumulate(tally: dict[str, int], usage) -> None:
+    """Add one turn's token usage, if the client reported any (the SDK response
+    carries ``.usage``; the scripted client carries none)."""
+    if usage is None:
+        return
+    tally["input"] += getattr(usage, "input_tokens", 0) or 0
+    tally["output"] += getattr(usage, "output_tokens", 0) or 0
 
 
 def _to_text(result: dict[str, Any]) -> str:

--- a/GeoAsk/app/routers/ask.py
+++ b/GeoAsk/app/routers/ask.py
@@ -39,12 +39,20 @@ class ClarificationModel(BaseModel):
     options: list[str]
 
 
+class UsageModel(BaseModel):
+    input_tokens: int
+    output_tokens: int
+    turns: int
+    est_cost_usd: float
+
+
 class AskResponse(BaseModel):
     finished: bool
     explanation: str
     geojson: dict[str, Any] | None
     trace: list[TraceStepModel]
     clarification: ClarificationModel | None = None
+    usage: UsageModel | None = None
 
 
 def _to_response(result) -> "AskResponse":
@@ -59,6 +67,13 @@ def _to_response(result) -> "AskResponse":
                                options=result.clarification.options)
             if result.clarification else None
         ),
+        usage=(
+            UsageModel(input_tokens=result.usage.input_tokens,
+                       output_tokens=result.usage.output_tokens,
+                       turns=result.usage.turns,
+                       est_cost_usd=result.usage.est_cost_usd)
+            if result.usage else None
+        ),
     )
 
 
@@ -66,10 +81,14 @@ def _to_response(result) -> "AskResponse":
 def ask_demo(variant: str = "gap"):
     """Run the orchestrator over in-memory sample data with a scripted planner —
     no API key or database needed. Lets the frontend be demoed end-to-end.
-    ``variant='clarify'`` shows the ask-a-follow-up flow."""
-    from ..orchestration.demo import run_clarify_demo, run_demo
+    ``variant='clarify'`` shows the ask-a-follow-up flow; ``'refine'`` shows a
+    stricter follow-up over the same question."""
+    from ..orchestration.demo import run_clarify_demo, run_demo, run_refine_demo
 
-    result = run_clarify_demo() if variant == "clarify" else run_demo()
+    result = {
+        "clarify": run_clarify_demo,
+        "refine": run_refine_demo,
+    }.get(variant, run_demo)()
     return _to_response(result)
 
 

--- a/GeoAsk/app/web/app.js
+++ b/GeoAsk/app/web/app.js
@@ -67,6 +67,8 @@ const SAMPLES = [
 
 // --- messaging --------------------------------------------------------------
 
+const REDUCED_MOTION = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
 function addMessage(text, kind, swatch) {
   const div = document.createElement("div");
   div.className = `msg ${kind}`;
@@ -74,6 +76,7 @@ function addMessage(text, kind, swatch) {
     const dot = document.createElement("span");
     dot.className = "swatch";
     dot.style.background = swatch;
+    dot.setAttribute("aria-hidden", "true");
     div.appendChild(dot);
   }
   div.appendChild(document.createTextNode(text));
@@ -85,6 +88,7 @@ function addMessage(text, kind, swatch) {
 function addThinking() {
   const div = addMessage("Working", "assistant");
   div.classList.add("thinking");
+  div.setAttribute("role", "status");
   return div;
 }
 
@@ -172,6 +176,52 @@ function addHint(container, text) {
   container.appendChild(div);
 }
 
+// Per-query LLM cost, so the operator can see what each question costs (the
+// plan flags cost as a risk to track). Hidden for the scripted demo (0 tokens).
+function addUsage(container, usage) {
+  if (!usage) return;
+  const tokens = (usage.input_tokens || 0) + (usage.output_tokens || 0);
+  if (tokens <= 0) return;
+  const cost = usage.est_cost_usd || 0;
+  const div = document.createElement("div");
+  div.className = "usage";
+  div.textContent = `${tokens.toLocaleString()} tokens · ~$${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)}`;
+  container.appendChild(div);
+}
+
+// Quick refinements of the current answer — the "now only show ones with >20%
+// seniors" loop from the plan, one tap.
+function addRefine(container, endpoint) {
+  const isDemo = endpoint.includes("/demo");
+  const refinements = isDemo
+    ? [["Only ≥20% seniors", "/ask/demo?variant=refine", null]]
+    : [
+        ["Only the ones with >20% seniors", "/ask", "but only where seniors are more than 20% of the population"],
+        ["Widen to a 15-minute drive", "/ask", "but use a 15-minute drive time"],
+      ];
+  const wrap = document.createElement("div");
+  wrap.className = "refine";
+  const label = document.createElement("span");
+  label.className = "refine-label";
+  label.textContent = "Refine:";
+  wrap.appendChild(label);
+  const row = document.createElement("div");
+  row.className = "options";
+  refinements.forEach(([text, ep, phrase]) => {
+    const b = document.createElement("button");
+    b.type = "button";
+    b.className = "chip";
+    b.textContent = text;
+    b.addEventListener("click", () => {
+      addMessage(text, "user");
+      submitQuestion(phrase ? `${lastQuestion} — ${phrase}` : text, ep);
+    });
+    row.appendChild(b);
+  });
+  wrap.appendChild(row);
+  container.appendChild(wrap);
+}
+
 function addTrace(container, trace) {
   const det = document.createElement("details");
   det.className = "trace";
@@ -219,7 +269,7 @@ function addResultLayer(geojson, name, color) {
       filter: ["==", ["geometry-type"], "Point"],
       paint: { "circle-color": color, "circle-radius": 6, "circle-stroke-color": "#fff", "circle-stroke-width": 1.5 } });
     const bb = bboxOf(geojson);
-    if (bb) map.fitBounds(bb, { padding: 60, maxZoom: 12, duration: 600 });
+    if (bb) map.fitBounds(bb, { padding: 60, maxZoom: 12, duration: REDUCED_MOTION ? 0 : 600 });
   });
   const layer = { id, name, color, sub, visible: true };
   state.layers.push(layer);
@@ -235,6 +285,7 @@ function renderLayerList() {
     const cb = document.createElement("input");
     cb.type = "checkbox";
     cb.checked = layer.visible;
+    cb.setAttribute("aria-label", `Show layer: ${layer.name}`);
     cb.addEventListener("change", () => {
       layer.visible = cb.checked;
       const v = cb.checked ? "visible" : "none";
@@ -243,6 +294,7 @@ function renderLayerList() {
     const sw = document.createElement("span");
     sw.className = "swatch";
     sw.style.background = layer.color;
+    sw.setAttribute("aria-hidden", "true");
     const label = document.createElement("span");
     label.textContent = layer.name;
     li.append(cb, sw, label);
@@ -297,10 +349,13 @@ async function submitQuestion(question, endpoint) {
     const msg = addMessage(data.explanation || "(no explanation)", "assistant", hasMap ? color : null);
 
     if (hasMap) {
-      // 2) A real answer — summary, plain-language readout, trace, map layer.
+      // 2) A real answer — summary, plain-language readout, trace, map layer,
+      //    cost, and one-tap refinements.
       addSummary(msg, data.geojson);
       addReadout(msg, data.geojson);
       if (data.trace && data.trace.length) addTrace(msg, data.trace);
+      addUsage(msg, data.usage);
+      addRefine(msg, endpoint);
       const count = data.geojson.features.length;
       addResultLayer(data.geojson, `${trimName(question)} (${count})`, color);
     } else if (data.finished) {

--- a/GeoAsk/app/web/index.html
+++ b/GeoAsk/app/web/index.html
@@ -15,7 +15,7 @@
         <p>Ask a spatial question in plain English. Get a map back.</p>
       </header>
 
-      <div id="messages" aria-live="polite"></div>
+      <div id="messages" role="log" aria-live="polite" aria-label="Conversation"></div>
 
       <section id="layers-panel" hidden>
         <h2>Layers</h2>
@@ -32,12 +32,12 @@
         <button type="submit" id="ask-button">Ask</button>
       </form>
       <div id="samples">
-        <span class="samples-label">Try a sample (no setup needed):</span>
-        <div id="chips"></div>
+        <span class="samples-label" id="samples-label">Try a sample (no setup needed):</span>
+        <div id="chips" role="group" aria-labelledby="samples-label"></div>
       </div>
     </aside>
 
-    <div id="map"></div>
+    <div id="map" role="region" aria-label="Result map"></div>
   </div>
 
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>

--- a/GeoAsk/app/web/styles.css
+++ b/GeoAsk/app/web/styles.css
@@ -99,12 +99,26 @@ body {
 .chip:hover { border-color: var(--accent); color: var(--accent); }
 .chip:disabled { opacity: .5; cursor: default; }
 
+/* Visible keyboard focus on every interactive control. */
+.chip:focus-visible, #ask-button:focus-visible, #layers input:focus-visible,
+.trace summary:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thinking::after { animation: none; }
+  * { scroll-behavior: auto; }
+}
+
 .summary { margin-top: 8px; font-size: 13px; color: var(--muted); }
 .summary strong { color: var(--text); }
 
 .readout { margin-top: 6px; font-size: 13px; color: var(--text); }
 .hint { margin-top: 8px; font-size: 13px; color: var(--muted); }
 .options { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.usage { margin-top: 8px; font-size: 12px; color: var(--muted); }
+.refine { margin-top: 10px; }
+.refine-label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 4px; }
 
 #map { flex: 1; }
 

--- a/GeoAsk/tests/test_frontend.py
+++ b/GeoAsk/tests/test_frontend.py
@@ -50,6 +50,28 @@ def test_demo_geojson_is_renderable():
     assert feat["geometry"]["coordinates"]
 
 
+def test_index_has_accessibility_landmarks():
+    body = client.get("/").text
+    assert 'role="log"' in body          # the conversation transcript
+    assert 'role="region"' in body       # the map
+    assert 'role="group"' in body        # the sample chips
+
+
+def test_demo_refine_variant_narrows_the_result():
+    data = client.post("/ask/demo?variant=refine").json()
+    assert data["finished"] is True
+    names = {f["properties"]["tract"] for f in data["geojson"]["features"]}
+    # Tighter senior threshold drops Powellhurst (19%).
+    assert names == {"Pleasant Vly", "Hazelwood"}
+
+
+def test_demo_reports_usage_shape():
+    data = client.post("/ask/demo").json()
+    # Scripted demo reports a usage object with zero tokens (no LLM cost).
+    assert data["usage"]["turns"] == 6
+    assert data["usage"]["est_cost_usd"] == 0.0
+
+
 def test_demo_clarify_variant_returns_a_clarification():
     data = client.post("/ask/demo?variant=clarify").json()
     assert data["finished"] is False

--- a/GeoAsk/tests/test_orchestration.py
+++ b/GeoAsk/tests/test_orchestration.py
@@ -144,6 +144,46 @@ def test_clarify_returns_a_question_with_options(source):
     assert result.clarification.options == ["Pharmacies", "Grocery stores"]
 
 
+# --- per-query cost tracking -------------------------------------------------
+
+class UsageLLM:
+    """A fake reporting token usage each turn (like the real SDK response)."""
+    model = "claude-opus-4-8"
+
+    def __init__(self, turns):
+        self._turns = turns
+        self._i = 0
+
+    def respond(self, system, tools, messages):
+        turn = self._turns[self._i]
+        self._i += 1
+        content = [_tool_use(f"u{self._i}_{j}", name, args) for j, (name, args) in enumerate(turn)]
+        return SimpleNamespace(content=content, stop_reason="tool_use",
+                               usage=SimpleNamespace(input_tokens=1000, output_tokens=200))
+
+
+def test_usage_is_accumulated_and_priced(source):
+    turns = [
+        [("load_pois", {"category": "pharmacy"})],
+        [("finish", {"layer_id": "layer_1", "explanation": "done"})],
+    ]
+    result = ask("show pharmacies", UsageLLM(turns), source)
+    u = result.usage
+    assert u.turns == 2
+    assert u.input_tokens == 2000 and u.output_tokens == 400
+    # opus-4-8: 2000/1e6*5 + 400/1e6*25 = 0.01 + 0.01
+    assert u.est_cost_usd == 0.02
+
+
+def test_usage_is_zero_when_client_reports_none(source):
+    # ScriptedLLM reports no usage; the demo/scripted path costs nothing.
+    turns = [[("load_pois", {"category": "pharmacy"})],
+             [("finish", {"layer_id": "layer_1", "explanation": "x"})]]
+    result = ask("q", ScriptedLLM(turns), source)
+    assert result.usage.input_tokens == 0
+    assert result.usage.est_cost_usd == 0.0
+
+
 # --- the design rule: the model never receives raw geometry ------------------
 
 def test_llm_never_sees_coordinates(source):


### PR DESCRIPTION
Three improvements to the pilot-ready MVP — the non-expansion items from the roadmap (holding on new products per the plan's post-Phase-5 decision gate). All continue to work and are tested offline with no API key or database.

## 1. Accessibility
Makes the UI usable with a keyboard and a screen reader:
- Landmark roles — `log` (conversation transcript), `region` (map), `group` (sample chips).
- Labelled layer toggles (`aria-label`), `aria-hidden` on decorative colour swatches.
- The busy indicator announces via `role="status"`.
- Visible keyboard focus rings (`:focus-visible`) on chips, buttons, checkboxes, and the trace toggle.
- `prefers-reduced-motion` disables the thinking animation and map fly-to.

## 2. One-tap refine
The plan's "now only show ones with >20% seniors" loop. After an answer, quick refinements — **"only ≥20% seniors"**, **"widen to a 15-minute drive"** — re-ask with the added constraint and drop the result in as a new **toggleable layer**, so you can compare. Offline demo (`/ask/demo?variant=refine`) narrows the 3 gap tracts to 2 (Powellhurst at 19% drops out); verified in a headless browser (screenshot: two stacked layers, "…(3)" and "Only ≥20% seniors (2)").

## 3. Per-query cost tracking
The plan flags LLM cost as a risk to track from Phase 2 on. The orchestrator now sums token usage across the agent loop and returns `Usage` (input/output tokens, turn count, estimated USD) on **every `/ask` response**; the UI shows it under each answer. The pricing table lives in `llm.py` as the single source of truth. The scripted demo reports zero tokens (no model), so the cost line is hidden there.

## Testing
- **61 tests pass** (+1 skipped live eval): usage accumulation + pricing math, the refine demo narrowing, the accessibility landmarks in the served page, and live-PostGIS integration (auto-skips without `DATABASE_URL`).

## Scope note
I held on the expansion roadmap (site-selection / change-detection) — the plan's decision gate says validate the pilot on the current engine before building new products. Say the word if you'd like me to prototype one anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUj97HpKXfyGFXSbjJbVZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUj97HpKXfyGFXSbjJbVZE)_